### PR TITLE
Add first archive block metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Here is an example [`scrape_config`](https://prometheus.io/docs/prometheus/lates
 | eth_latest_block_transactions | Number of transactions in the latest block. |
 | eth_pending_block_transactions | The number of transactions in pending block. |
 | eth_hashrate | Hashes per second that this node is mining with. |
+| eth_first_archive_block_number | Earliest block whose state the node still retains. Found by binary search over `eth_getBalance`, refreshed in the background every `-ethfirstarchiveblockinterval` (default `1h`). |
 | eth_sync_starting | Block number at which current import started. |
 | eth_sync_current | Number of most recent block. |
 | eth_sync_highest | Estimated number of highest block. |

--- a/cmd/ethereum_exporter/main.go
+++ b/cmd/ethereum_exporter/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/31z4/ethereum-prometheus-exporter/internal/collector"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -45,6 +46,9 @@ func main() {
 	ethhashrate := flag.Bool("ethhashrate", true, "ethhashrate metrics on/off switch")
 	ethsyncing := flag.Bool("ethsyncing", false, "ethsyncing metrics on/off switch")
 	paritynetpeers := flag.Bool("paritynetpeers", false, "paritynetpeers metrics on/off switch")
+
+	ethfirstarchiveblocknumber := flag.Bool("ethfirstarchiveblocknumber", true, "ethfirstarchiveblocknumber metrics on/off switch")
+	ethfirstarchiveblockinterval := flag.Duration("ethfirstarchiveblockinterval", time.Hour, "how often to search for the first archive block")
 
 	flag.Parse()
 	if len(flag.Args()) > 0 {
@@ -125,6 +129,12 @@ func main() {
 	if *paritynetpeers {
 		registry.MustRegister(
 			collector.NewParityNetPeers(rpc),
+		)
+	}
+
+	if *ethfirstarchiveblocknumber {
+		registry.MustRegister(
+			collector.NewEthFirstArchiveBlockNumber(rpc, *ethfirstarchiveblockinterval),
 		)
 	}
 

--- a/internal/collector/eth_first_archive_block_number.go
+++ b/internal/collector/eth_first_archive_block_number.go
@@ -1,0 +1,189 @@
+package collector
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// zeroAddress is the account probed with eth_getBalance to decide whether the
+// node still serves state at a given height. Any address works, the zero
+// address is just guaranteed to be resolvable in every state trie.
+const zeroAddress = "0x0000000000000000000000000000000000000000"
+
+// archiveProbeCandidates seed the upper bound of the binary search when the head
+// block is unknown or serves no state.
+var archiveProbeCandidates = []uint64{1_000_000, 5_000_000, 10_000_000, 20_000_000, 50_000_000, 100_000_000, 500_000_000}
+
+var errSearchPending = errors.New("first archive block search has not completed yet")
+
+// EthFirstArchiveBlockNumber reports the earliest block whose state the node
+// still retains. It mirrors the probe used by `proverator nodes info
+// --check-archive`: binary search over eth_getBalance, which succeeds only at
+// heights the node has not pruned.
+//
+// The search costs about log2(head) sequential state reads (~25 on mainnet), so
+// it is far too expensive to run on every scrape. A background goroutine
+// refreshes the value on a fixed interval instead, and Collect serves the last
+// result.
+type EthFirstArchiveBlockNumber struct {
+	rpc  *rpc.Client
+	desc *prometheus.Desc
+
+	mu    sync.RWMutex
+	block uint64
+	err   error
+}
+
+// NewEthFirstArchiveBlockNumber starts a background refresh loop that keeps
+// probing the node every interval, and never stops. That is fine because the
+// exporter registers its collectors once and then runs until the process exits.
+func NewEthFirstArchiveBlockNumber(rpc *rpc.Client, interval time.Duration) *EthFirstArchiveBlockNumber {
+	collector := newEthFirstArchiveBlockNumber(rpc)
+
+	go collector.refreshLoop(interval)
+
+	return collector
+}
+
+// newEthFirstArchiveBlockNumber builds the collector without starting the
+// refresh loop, so tests can drive refresh themselves.
+func newEthFirstArchiveBlockNumber(rpc *rpc.Client) *EthFirstArchiveBlockNumber {
+	return &EthFirstArchiveBlockNumber{
+		rpc: rpc,
+		desc: prometheus.NewDesc(
+			"eth_first_archive_block_number",
+			"earliest block whose state the node still retains",
+			nil,
+			nil,
+		),
+		err: errSearchPending,
+	}
+}
+
+func (collector *EthFirstArchiveBlockNumber) Describe(ch chan<- *prometheus.Desc) {
+	ch <- collector.desc
+}
+
+func (collector *EthFirstArchiveBlockNumber) Collect(ch chan<- prometheus.Metric) {
+	collector.mu.RLock()
+	block, err := collector.block, collector.err
+	collector.mu.RUnlock()
+
+	if err != nil {
+		ch <- prometheus.NewInvalidMetric(collector.desc, err)
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(collector.desc, prometheus.GaugeValue, float64(block))
+}
+
+func (collector *EthFirstArchiveBlockNumber) refreshLoop(interval time.Duration) {
+	collector.refresh()
+
+	for range time.Tick(interval) {
+		collector.refresh()
+	}
+}
+
+// refresh runs one search and stores the outcome. A failed search replaces the
+// previous value with an error rather than serving a stale block number.
+func (collector *EthFirstArchiveBlockNumber) refresh() {
+	started := time.Now()
+
+	// A missing head only widens the search, so an error here is not fatal.
+	head, err := collector.headBlock()
+	if err != nil {
+		log.Printf("eth_first_archive_block_number: cannot read head block: %v", err)
+	}
+
+	block, probes, err := collector.findFirstArchiveBlock(head)
+	if err != nil {
+		log.Printf("eth_first_archive_block_number: search failed after %d probes: %v", probes, err)
+	} else {
+		log.Printf("eth_first_archive_block_number: %d (head %d, %d probes, %s)", block, head, probes, time.Since(started).Round(time.Millisecond))
+	}
+
+	collector.mu.Lock()
+	collector.block, collector.err = block, err
+	collector.mu.Unlock()
+}
+
+// findFirstArchiveBlock binary-searches the earliest block whose state the node
+// still serves, and reports how many probes it took. head, when non-zero, seeds
+// the upper bound.
+func (collector *EthFirstArchiveBlockNumber) findFirstArchiveBlock(head uint64) (uint64, int, error) {
+	probes := 0
+	hasState := func(block uint64) bool {
+		probes++
+		return collector.hasState(block)
+	}
+
+	if hasState(1) {
+		return 1, probes, nil
+	}
+
+	var high uint64
+	if head > 0 && hasState(head) {
+		high = head
+	}
+	if high == 0 {
+		for _, candidate := range archiveProbeCandidates {
+			if hasState(candidate) {
+				high = candidate
+				break
+			}
+		}
+	}
+	if high == 0 {
+		if !collector.reachable() {
+			return 0, probes, errors.New("node unreachable")
+		}
+		return 0, probes, errors.New("node serves no state at any probed height")
+	}
+
+	var low uint64
+	for high-low > 1 {
+		mid := (low + high) / 2
+		if hasState(mid) {
+			high = mid
+		} else {
+			low = mid
+		}
+	}
+
+	return high, probes, nil
+}
+
+// hasState reports whether the node still serves state at block by asking for a
+// balance at that height. Pruned state answers with an RPC error instead.
+func (collector *EthFirstArchiveBlockNumber) hasState(block uint64) bool {
+	var result json.RawMessage
+	if err := collector.rpc.Call(&result, "eth_getBalance", zeroAddress, hexutil.EncodeUint64(block)); err != nil {
+		return false
+	}
+
+	return len(result) > 0 && string(result) != "null"
+}
+
+// reachable distinguishes an unreachable node from one that simply serves no
+// state, so a failed search says which of the two happened.
+func (collector *EthFirstArchiveBlockNumber) reachable() bool {
+	var version string
+	return collector.rpc.Call(&version, "web3_clientVersion") == nil
+}
+
+func (collector *EthFirstArchiveBlockNumber) headBlock() (uint64, error) {
+	var result hexutil.Uint64
+	if err := collector.rpc.Call(&result, "eth_blockNumber"); err != nil {
+		return 0, err
+	}
+
+	return uint64(result), nil
+}

--- a/internal/collector/eth_first_archive_block_number_test.go
+++ b/internal/collector/eth_first_archive_block_number_test.go
@@ -1,0 +1,264 @@
+package collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// fakeNode serves the subset of JSON-RPC the archive search uses, retaining
+// state only from firstArchive onwards. It counts eth_getBalance calls so tests
+// can assert on probe cost.
+type fakeNode struct {
+	head         uint64
+	firstArchive uint64 // 0 means the node serves no state at all
+	probes       int
+}
+
+func (n *fakeNode) server(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+			Params []string        `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("could not decode request: %#v", err)
+			return
+		}
+
+		reply := func(format string, args ...interface{}) {
+			body := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,`+format+`}`, append([]interface{}{req.ID}, args...)...)
+			if _, err := w.Write([]byte(body)); err != nil {
+				t.Errorf("could not write a response: %#v", err)
+			}
+		}
+
+		switch req.Method {
+		case "web3_clientVersion":
+			reply(`"result":"fake/v1.0.0"`)
+
+		case "eth_blockNumber":
+			reply(`"result":%q`, hexutil.EncodeUint64(n.head))
+
+		case "eth_getBalance":
+			n.probes++
+
+			block, err := hexutil.DecodeUint64(req.Params[1])
+			if err != nil {
+				t.Errorf("could not decode block %q: %#v", req.Params[1], err)
+				return
+			}
+			// Geth answers a pruned height with an error, not a null result.
+			if n.firstArchive == 0 || block < n.firstArchive || block > n.head {
+				reply(`"error":{"code":-32000,"message":"missing trie node"}`)
+				return
+			}
+			reply(`"result":"0x0"`)
+
+		default:
+			reply(`"error":{"code":-32601,"message":"method not found"}`)
+		}
+	}))
+}
+
+func TestEthFirstArchiveBlockNumberFindFirstArchiveBlock(t *testing.T) {
+	tests := []struct {
+		name         string
+		head         uint64
+		firstArchive uint64
+		wantProbes   int
+	}{
+		{name: "full archive from genesis", head: 16_000_000, firstArchive: 1, wantProbes: 1},
+		{name: "pruned node", head: 16_000_000, firstArchive: 15_500_000},
+		{name: "state only at head", head: 16_000_000, firstArchive: 16_000_000},
+		{name: "small chain", head: 4_200, firstArchive: 3_000},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			node := &fakeNode{head: test.head, firstArchive: test.firstArchive}
+			server := node.server(t)
+			defer server.Close()
+
+			client, err := rpc.DialHTTP(server.URL)
+			if err != nil {
+				t.Fatalf("rpc connection error: %#v", err)
+			}
+
+			collector := newEthFirstArchiveBlockNumber(client)
+			got, probes, err := collector.findFirstArchiveBlock(test.head)
+			if err != nil {
+				t.Fatalf("unexpected error: %#v", err)
+			}
+			if got != test.firstArchive {
+				t.Fatalf("got %d, want %d", got, test.firstArchive)
+			}
+			if test.wantProbes > 0 && probes != test.wantProbes {
+				t.Fatalf("got %d probes, want %d", probes, test.wantProbes)
+			}
+		})
+	}
+}
+
+// When the head block is unknown the search falls back to the hard-coded
+// candidates, which bound it only if one of them happens to be retained. A node
+// whose retained range sits entirely between two candidates cannot be bounded,
+// so the search reports no state rather than guessing. This matches proverator.
+func TestEthFirstArchiveBlockNumberWithoutHead(t *testing.T) {
+	tests := []struct {
+		name         string
+		head         uint64
+		firstArchive uint64
+		want         uint64
+		wantErr      bool
+	}{
+		{name: "candidate is retained", head: 16_000_000, firstArchive: 9_000_000, want: 9_000_000},
+		{name: "no candidate is retained", head: 16_000_000, firstArchive: 15_500_000, wantErr: true},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			node := &fakeNode{head: test.head, firstArchive: test.firstArchive}
+			server := node.server(t)
+			defer server.Close()
+
+			client, err := rpc.DialHTTP(server.URL)
+			if err != nil {
+				t.Fatalf("rpc connection error: %#v", err)
+			}
+
+			collector := newEthFirstArchiveBlockNumber(client)
+			got, _, err := collector.findFirstArchiveBlock(0)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got block %d", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %#v", err)
+			}
+			if got != test.want {
+				t.Fatalf("got %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestEthFirstArchiveBlockNumberNoState(t *testing.T) {
+	node := &fakeNode{head: 16_000_000}
+	server := node.server(t)
+	defer server.Close()
+
+	client, err := rpc.DialHTTP(server.URL)
+	if err != nil {
+		t.Fatalf("rpc connection error: %#v", err)
+	}
+
+	collector := newEthFirstArchiveBlockNumber(client)
+	if _, _, err := collector.findFirstArchiveBlock(16_000_000); err == nil {
+		t.Fatal("expected an error, got none")
+	}
+}
+
+func TestEthFirstArchiveBlockNumberCollect(t *testing.T) {
+	node := &fakeNode{head: 16_000_000, firstArchive: 15_500_000}
+	server := node.server(t)
+	defer server.Close()
+
+	client, err := rpc.DialHTTP(server.URL)
+	if err != nil {
+		t.Fatalf("rpc connection error: %#v", err)
+	}
+
+	collector := newEthFirstArchiveBlockNumber(client)
+	collector.refresh()
+
+	ch := make(chan prometheus.Metric, 1)
+	collector.Collect(ch)
+	close(ch)
+
+	if got := len(ch); got != 1 {
+		t.Fatalf("got %v, want 1", got)
+	}
+
+	var metric dto.Metric
+	for result := range ch {
+		if err := result.Write(&metric); err != nil {
+			t.Fatalf("expected metric, got %#v", err)
+		}
+		if got := len(metric.Label); got > 0 {
+			t.Fatalf("expected 0 labels, got %d", got)
+		}
+		if got := *metric.Gauge.Value; got != 15_500_000 {
+			t.Fatalf("got %v, want 15500000", got)
+		}
+	}
+}
+
+// Until the first search completes, Collect must report an error rather than a
+// zero block number.
+func TestEthFirstArchiveBlockNumberCollectPending(t *testing.T) {
+	client, err := rpc.DialHTTP("http://localhost")
+	if err != nil {
+		t.Fatalf("rpc connection error: %#v", err)
+	}
+
+	collector := newEthFirstArchiveBlockNumber(client)
+	ch := make(chan prometheus.Metric, 1)
+
+	collector.Collect(ch)
+	close(ch)
+
+	if got := len(ch); got != 1 {
+		t.Fatalf("got %v, want 1", got)
+	}
+
+	for result := range ch {
+		var metric dto.Metric
+		if err := result.Write(&metric); err != errSearchPending {
+			t.Fatalf("got %#v, want errSearchPending", err)
+		}
+	}
+}
+
+func TestEthFirstArchiveBlockNumberCollectError(t *testing.T) {
+	client, err := rpc.DialHTTP("http://localhost")
+	if err != nil {
+		t.Fatalf("rpc connection error: %#v", err)
+	}
+
+	collector := newEthFirstArchiveBlockNumber(client)
+	collector.refresh()
+
+	ch := make(chan prometheus.Metric, 1)
+	collector.Collect(ch)
+	close(ch)
+
+	if got := len(ch); got != 1 {
+		t.Fatalf("got %v, want 1", got)
+	}
+
+	for result := range ch {
+		var metric dto.Metric
+		err := result.Write(&metric)
+		if err == nil {
+			t.Fatalf("expected invalid metric, got %#v", metric)
+		}
+		if _, ok := err.(*url.Error); ok {
+			t.Fatalf("unexpected error %#v", err)
+		}
+	}
+}


### PR DESCRIPTION
Exposes `eth_first_archive_block_number` — the earliest block whose state the node still retains — so it can be shown as a stat panel in Grafana.

- Ports the probe from `proverator nodes info --check-archive`: binary search over `eth_getBalance(0x0, <block>)`, which only succeeds at heights the node has not pruned.
- The search costs ~25 sequential state reads, so a background goroutine refreshes it every `-ethfirstarchiveblockinterval` (default `1h`) and `Collect` serves the cached value. Probing during a scrape would risk blowing the scrape timeout.
- Enabled by default via `-ethfirstarchiveblocknumber`. Useful on pruned nodes too, where it shows the retention floor.
- Until the first search completes, and after any failed refresh, the series is absent rather than `0` — so a broken node reads as "No data" instead of a misleading number. Use `last()` over a window wider than the refresh interval in Grafana.

🤖 Written by Claude Code